### PR TITLE
Trinkey2040 port

### DIFF
--- a/ports/rp2/boards/ADAFRUIT_TRINKEY_QT2040/board.json
+++ b/ports/rp2/boards/ADAFRUIT_TRINKEY_QT2040/board.json
@@ -1,0 +1,20 @@
+{
+  "deploy": [
+      "../deploy.md"
+  ],
+  "docs": "",
+  "features": [
+      "Built-in USB-A",
+      "RGB LED",
+      "SPI Flash",
+      "STEMMA QT/QWIIC"
+  ],
+  "images": [
+      "5056-12.jpg"
+  ],
+  "mcu": "rp2040",
+  "product": "Trinkey RP2040",
+  "thumbnail": "",
+  "url": "https://www.adafruit.com/product/5056",
+  "vendor": "Adafruit"
+}

--- a/ports/rp2/boards/ADAFRUIT_TRINKEY_QT2040/mpconfigboard.cmake
+++ b/ports/rp2/boards/ADAFRUIT_TRINKEY_QT2040/mpconfigboard.cmake
@@ -1,0 +1,1 @@
+# cmake file for Adafruit QT Py RP2040

--- a/ports/rp2/boards/ADAFRUIT_TRINKEY_QT2040/mpconfigboard.h
+++ b/ports/rp2/boards/ADAFRUIT_TRINKEY_QT2040/mpconfigboard.h
@@ -1,0 +1,14 @@
+// https://www.adafruit.com/product/5056
+// https://github.com/adafruit/circuitpython/blob/main/ports/raspberrypi/boards/adafruit_qt2040_trinkey/mpconfigboard.h
+// https://learn.adafruit.com/adafruit-trinkey-qt2040/pinouts
+
+#define MICROPY_HW_BOARD_NAME          "Adafruit Trinkey QT2040"
+#define MICROPY_HW_FLASH_STORAGE_BYTES (7 * 1024 * 1024)
+
+#define MICROPY_HW_NEOPIXEL (&pin_GPIO27)
+
+#define DEFAULT_I2C_BUS_SCL (&pin_GPIO17)
+#define DEFAULT_I2C_BUS_SDA (&pin_GPIO16)
+
+#define DEFAULT_UART_BUS_RX (&pin_GPIO17)
+#define DEFAULT_UART_BUS_TX (&pin_GPIO16)

--- a/ports/rp2/boards/ADAFRUIT_TRINKEY_RP2040/board.json
+++ b/ports/rp2/boards/ADAFRUIT_TRINKEY_RP2040/board.json
@@ -1,0 +1,20 @@
+{
+  "deploy": [
+      "../deploy.md"
+  ],
+  "docs": "",
+  "features": [
+      "Built-in USB-A",
+      "RGB LED",
+      "SPI Flash",
+      "STEMMA QT/QWIIC"
+  ],
+  "images": [
+      "5056-12.jpg"
+  ],
+  "mcu": "rp2040",
+  "product": "Trinkey RP2040",
+  "thumbnail": "",
+  "url": "https://www.adafruit.com/product/5056",
+  "vendor": "Adafruit"
+}

--- a/ports/rp2/boards/ADAFRUIT_TRINKEY_RP2040/mpconfigboard.cmake
+++ b/ports/rp2/boards/ADAFRUIT_TRINKEY_RP2040/mpconfigboard.cmake
@@ -1,0 +1,1 @@
+# cmake file for Adafruit QT Py RP2040

--- a/ports/rp2/boards/ADAFRUIT_TRINKEY_RP2040/mpconfigboard.h
+++ b/ports/rp2/boards/ADAFRUIT_TRINKEY_RP2040/mpconfigboard.h
@@ -1,0 +1,15 @@
+// https://www.adafruit.com/product/5056
+// https://github.com/adafruit/circuitpython/blob/main/ports/raspberrypi/boards/adafruit_qt2040_trinkey/mpconfigboard.h
+// https://learn.adafruit.com/adafruit-trinkey-qt2040/pinouts
+
+#define MICROPY_HW_BOARD_NAME          "Adafruit Trinkey RP2040"
+#define MICROPY_HW_FLASH_STORAGE_BYTES (7 * 1024 * 1024)
+#define MICROPY_HW_MCU_NAME            "rp2040"
+
+#define MICROPY_HW_NEOPIXEL (&pin_GPIO27)
+
+#define DEFAULT_I2C_BUS_SCL (&pin_GPIO17)
+#define DEFAULT_I2C_BUS_SDA (&pin_GPIO16)
+
+#define DEFAULT_UART_BUS_RX (&pin_GPIO17)
+#define DEFAULT_UART_BUS_TX (&pin_GPIO16)


### PR DESCRIPTION
Micropython port for the Adafruit Trinkey 2040 board. First attempt did not work because the name of the board in the [linked pico-sdk file](https://github.com/raspberrypi/pico-sdk/blob/2062372d203b372849d573f252cf7c6dc2800c0a/src/boards/include/boards/adafruit_trinkey_qt2040.h) is actually `adafruit_trinkey_qt2040` and the original name was `adafruit_trinkey_**rp**2040`. Builds with no errors but still needs testing on the board.